### PR TITLE
Added Jira extra functionality

### DIFF
--- a/src/main/java/com/checkmarx/flow/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/CxProperties.java
@@ -39,6 +39,7 @@ public class CxProperties {
     private Integer incrementalThreshold = 7;
     private Integer incrementalNumScans = 5;
     private String team;
+    private Boolean nonamespace = false;
     private Boolean offline = false;
     private Boolean preserveXml = false;
     private Integer scanTimeout = 120;
@@ -107,6 +108,14 @@ public class CxProperties {
 
     public String getScanPreset() {
         return this.scanPreset;
+    }
+
+    public Boolean getNonamespace() {
+        return nonamespace;
+    }
+
+    public void setNonamespace(Boolean nonamespace) {
+        this.nonamespace = nonamespace;
     }
 
     public String getConfiguration() {

--- a/src/main/java/com/checkmarx/flow/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/CxProperties.java
@@ -39,7 +39,6 @@ public class CxProperties {
     private Integer incrementalThreshold = 7;
     private Integer incrementalNumScans = 5;
     private String team;
-    private Boolean nonamespace = false;
     private Boolean offline = false;
     private Boolean preserveXml = false;
     private Integer scanTimeout = 120;
@@ -109,15 +108,7 @@ public class CxProperties {
     public String getScanPreset() {
         return this.scanPreset;
     }
-
-    public Boolean getNonamespace() {
-        return nonamespace;
-    }
-
-    public void setNonamespace(Boolean nonamespace) {
-        this.nonamespace = nonamespace;
-    }
-
+    
     public String getConfiguration() {
         return this.configuration;
     }

--- a/src/main/java/com/checkmarx/flow/config/FlowProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/FlowProperties.java
@@ -22,6 +22,7 @@ public class FlowProperties {
     private List<String> filterCategory;
     private List<String> filterStatus;
     private boolean trackApplicationOnly = false;
+    private boolean ApplicationRepoOnly = false;
     private String branchScript;
     private String mitreUrl;
     private String wikiUrl;
@@ -251,4 +252,13 @@ public class FlowProperties {
         }
 
     }
+
+    public boolean isApplicationRepoOnly() {
+        return ApplicationRepoOnly;
+    }
+
+    public void setApplicationRepoOnly(boolean ApplicationRepoOnly) {
+        this.ApplicationRepoOnly = ApplicationRepoOnly;
+    }
+    
 }

--- a/src/main/java/com/checkmarx/flow/config/JiraProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/JiraProperties.java
@@ -38,6 +38,8 @@ public class JiraProperties {
     private List<String> openStatus;
     private List<String> closedStatus;
     private List<Field> fields;
+    private String ParentUrl = "";
+    private boolean child = false;
 
     public String getUrl() {
         return this.url;
@@ -246,4 +248,21 @@ public class JiraProperties {
     public void setFields(List<Field> fields) {
         this.fields = fields;
     }
+
+    public String getParentUrl() {
+        return ParentUrl;
+    }
+
+    public void setParentUrl(String ParentUrl) {
+        this.ParentUrl = ParentUrl;
+    }
+
+    public boolean isChild() {
+        return child;
+    }
+
+    public void setChild(boolean child) {
+        this.child = child;
+    }
+    
 }

--- a/src/main/java/com/checkmarx/flow/service/CxService.java
+++ b/src/main/java/com/checkmarx/flow/service/CxService.java
@@ -1168,7 +1168,11 @@ public class CxService {
         try {
             session = cxLegacyService.login(cxProperties.getUsername(), cxProperties.getPassword());
             cxLegacyService.createTeam(session, parentTeamId, teamName);
+            if(!cxProperties.getNonamespace() ){
             return getTeamId(cxProperties.getTeam().concat("\\").concat(teamName));
+            }else{
+            return getTeamId(cxProperties.getTeam());
+            }
         } catch (CheckmarxLegacyException e) {
             log.error("Error occurring while logging into Legacy SOAP based WebService to create new team {} under parent {}", teamName, parentTeamId);
             throw new MachinaException("Error logging into legacy SOAP WebService for Team Creation");

--- a/src/main/java/com/checkmarx/flow/service/CxService.java
+++ b/src/main/java/com/checkmarx/flow/service/CxService.java
@@ -1168,11 +1168,7 @@ public class CxService {
         try {
             session = cxLegacyService.login(cxProperties.getUsername(), cxProperties.getPassword());
             cxLegacyService.createTeam(session, parentTeamId, teamName);
-            if(!cxProperties.getNonamespace() ){
             return getTeamId(cxProperties.getTeam().concat("\\").concat(teamName));
-            }else{
-            return getTeamId(cxProperties.getTeam());
-            }
         } catch (CheckmarxLegacyException e) {
             log.error("Error occurring while logging into Legacy SOAP based WebService to create new team {} under parent {}", teamName, parentTeamId);
             throw new MachinaException("Error logging into legacy SOAP WebService for Team Creation");

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -30,7 +30,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
-
 @Service
 public class JiraService {
 
@@ -43,16 +42,19 @@ public class JiraService {
     private final JiraProperties jiraProperties;
     private final FlowProperties flowProperties;
     private static final int MAX_JQL_RESULTS = 1000000;
+    private final String ParentUrl;
+    private ScanRequest Parent;
 
     @ConstructorProperties({"jiraProperties", "flowProperties"})
     public JiraService(JiraProperties jiraProperties, FlowProperties flowProperties) {
         this.jiraProperties = jiraProperties;
         this.flowProperties = flowProperties;
+        ParentUrl = jiraProperties.getParentUrl();        
     }
 
     @PostConstruct
     public void init() {
-        if(jiraProperties != null && !ScanUtils.empty(jiraProperties.getUrl())) {
+        if (jiraProperties != null && !ScanUtils.empty(jiraProperties.getUrl())) {
             JiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
 
             try {
@@ -73,10 +75,11 @@ public class JiraService {
         String jql;
         BugTracker bugTracker = request.getBugTracker();
         /*Namespace/Repo/Branch provided*/
-        if(!flowProperties.isTrackApplicationOnly() &&
-                !ScanUtils.empty(request.getNamespace()) &&
-                !ScanUtils.empty(request.getRepoName()) &&
-                !ScanUtils.empty(request.getBranch())) {
+        if (!flowProperties.isTrackApplicationOnly()
+                && !flowProperties.isApplicationRepoOnly()
+                && !ScanUtils.empty(request.getNamespace())
+                && !ScanUtils.empty(request.getRepoName())
+                && !ScanUtils.empty(request.getBranch())) {
             jql = String.format("project = %s and issueType = \"%s\" and (\"%s\" = \"%s\" and \"%s\" = \"%s:%s\" and \"%s\" = \"%s:%s\" and \"%s\" = \"%s:%s\")",
                     bugTracker.getProjectKey(),
                     bugTracker.getIssueType(),
@@ -89,8 +92,20 @@ public class JiraService {
                     jiraProperties.getLabelTracker(),
                     jiraProperties.getBranchLabelPrefix(), request.getBranch()
             );
-        }/*Only application provided*/
-        else if(!ScanUtils.empty(request.getApplication())){
+        }/*Only application and repo provided */ else if (!ScanUtils.empty(request.getApplication()) && !ScanUtils.empty(request.getRepoName())) {
+
+            jql = String.format("project = %s and issueType = \"%s\" and (\"%s\" = \"%s\" and \"%s\" = \"%s:%s\" and \"%s\" = \"%s:%s\")",
+                    bugTracker.getProjectKey(),
+                    bugTracker.getIssueType(),
+                    jiraProperties.getLabelTracker(),
+                    request.getProduct().getProduct(),
+                    jiraProperties.getLabelTracker(),
+                    jiraProperties.getAppLabelPrefix(), request.getApplication(),
+                    jiraProperties.getLabelTracker(),
+                    jiraProperties.getRepoLabelPrefix(), request.getRepoName()
+            );
+
+        }/*Only application provided*/ else if (!ScanUtils.empty(request.getApplication())) {
             jql = String.format("project = %s and issueType = \"%s\" and (\"%s\" = \"%s\" and \"%s\" = \"%s:%s\")",
                     bugTracker.getProjectKey(),
                     bugTracker.getIssueType(),
@@ -99,8 +114,7 @@ public class JiraService {
                     jiraProperties.getLabelTracker(),
                     jiraProperties.getAppLabelPrefix(), request.getApplication()
             );
-        }
-        else{
+        } else {
             log.error("Namespace/Repo/Branch or App must be provided in order to properly track ");
             throw new MachinaRuntimeException();
         }
@@ -119,9 +133,9 @@ public class JiraService {
     private IssueType getIssueType(String projectKey, String type) throws RestClientException, JiraClientException {
         Project project = this.projectClient.getProject(projectKey).claim();
         Iterator<IssueType> issueTypes = project.getIssueTypes().iterator();
-        while(issueTypes.hasNext()){
+        while (issueTypes.hasNext()) {
             IssueType it = issueTypes.next();
-            if(it.getName().equals(type)){
+            if (it.getName().equals(type)) {
                 return it;
             }
         }
@@ -129,10 +143,9 @@ public class JiraService {
         throw new JiraClientException("Issue type not found");
     }
 
-
-    private String createIssue(ScanResults.XIssue issue, ScanRequest request) throws JiraClientException{
+    private String createIssue(ScanResults.XIssue issue, ScanRequest request) throws JiraClientException {
         log.debug("Retrieving issuetype object for project {}, type {}", request.getBugTracker().getProjectKey(), request.getBugTracker().getIssueType());
-        try{
+        try {
             BugTracker bugTracker = request.getBugTracker();
             String assignee = bugTracker.getAssignee();
             String projectKey = bugTracker.getProjectKey();
@@ -149,24 +162,24 @@ public class JiraService {
             String issuePrefix = jiraProperties.getIssuePrefix();
             String issuePostfix = jiraProperties.getIssuePostfix();
 
-            if(issuePrefix == null){
+            if (issuePrefix == null) {
                 issuePrefix = "";
             }
-            if(issuePostfix == null){
+            if (issuePostfix == null) {
                 issuePostfix = "";
             }
 
             String summary;
-            if(!flowProperties.isTrackApplicationOnly() &&
-                    !ScanUtils.empty(namespace) &&
-                    !ScanUtils.empty(repoName) &&
-                    !ScanUtils.empty(branch)) {
-                summary = String.format(ScanUtils.JIRA_ISSUE_KEY, issuePrefix, vulnerability, filename, branch, issuePostfix);
+            if (!flowProperties.isTrackApplicationOnly()
+                    && !flowProperties.isApplicationRepoOnly()
+                    && !ScanUtils.empty(namespace)
+                    && !ScanUtils.empty(repoName)
+                    && !ScanUtils.empty(branch)) {
+                summary = String.format(ScanUtils.JIRA_ISSUE_KEY, issuePrefix, vulnerability, filename, branch,issuePostfix);
+            } else {
+                summary = String.format(ScanUtils.JIRA_ISSUE_KEY_2, issuePrefix, vulnerability, filename,issuePostfix);
             }
-            else{
-                summary = String.format(ScanUtils.JIRA_ISSUE_KEY_2, issuePrefix, vulnerability, filename, issuePostfix);
-            }
-            String fileUrl = ScanUtils.getFileUrl(request,issue.getFilename());
+            String fileUrl = ScanUtils.getFileUrl(request, issue.getFilename());
 
             /* Summary can only be 255 chars */
             if (summary.length() > 255) {
@@ -176,43 +189,46 @@ public class JiraService {
 
             issueBuilder.setDescription(this.getBody(issue, request, fileUrl));
 
-            if(assignee != null && !assignee.isEmpty()){
-                try{
+            if (assignee != null && !assignee.isEmpty()) {
+                try {
                     User userAssignee = getAssignee(assignee);
                     issueBuilder.setAssignee(userAssignee);
-                }catch(RestClientException e) {
+                } catch (RestClientException e) {
                     log.error("Error occurred while assigning to user {}", assignee);
                     log.error(ExceptionUtils.getStackTrace(e));
                 }
             }
 
-            if(bugTracker.getPriorities().containsKey(severity)) {
+            if (bugTracker.getPriorities().containsKey(severity)) {
                 issueBuilder.setFieldValue("priority", ComplexIssueInputFieldValue.with("name",
                         bugTracker.getPriorities().get(severity)));
             }
 
             /*Add labels for tracking existing issues*/
             List<String> labels = new ArrayList<>();
-            if(!flowProperties.isTrackApplicationOnly() &&
-                    !ScanUtils.empty(namespace) &&
-                    !ScanUtils.empty(repoName) &&
-                    !ScanUtils.empty(branch)) {
+            if (!flowProperties.isTrackApplicationOnly()
+                    && !flowProperties.isApplicationRepoOnly()
+                    && !ScanUtils.empty(namespace)
+                    && !ScanUtils.empty(repoName)
+                    && !ScanUtils.empty(branch)) {
                 labels.add(request.getProduct().getProduct());
                 labels.add(jiraProperties.getOwnerLabelPrefix().concat(":").concat(namespace));
                 labels.add(jiraProperties.getRepoLabelPrefix().concat(":").concat(repoName));
                 labels.add(jiraProperties.getBranchLabelPrefix().concat(":").concat(branch));
-            }
-            else if(!ScanUtils.empty(application)){
+            } else if (!ScanUtils.empty(application) && !ScanUtils.empty(repoName)) {
+                labels.add(request.getProduct().getProduct());
+                labels.add(jiraProperties.getAppLabelPrefix().concat(":").concat(application));
+                labels.add(jiraProperties.getRepoLabelPrefix().concat(":").concat(repoName));
+            } else if (!ScanUtils.empty(application)) {
                 labels.add(request.getProduct().getProduct());
                 labels.add(jiraProperties.getAppLabelPrefix().concat(":").concat(application));
             }
             log.debug("Adding tracker labels: {} - {}", jiraProperties.getLabelTracker(), labels);
-            if(!jiraProperties.getLabelTracker().equals("labels")){
+            if (!jiraProperties.getLabelTracker().equals("labels")) {
                 String customField = getCustomFieldByName(projectKey,
                         bugTracker.getIssueType(), jiraProperties.getLabelTracker());
                 issueBuilder.setFieldValue(customField, labels);
-            }
-            else{
+            } else {
                 issueBuilder.setFieldValue("labels", labels);
             }
 
@@ -225,25 +241,25 @@ public class JiraService {
             BasicIssue basicIssue = this.issueClient.createIssue(issueBuilder.build()).claim();
             log.debug("JIRA issue {} created", basicIssue.getKey());
             return basicIssue.getKey();
-        }catch (RestClientException e){
+        } catch (RestClientException e) {
             log.error("Error occurred while creating JIRA issue. {}", e.getMessage());
             log.error(ExceptionUtils.getStackTrace(e));
             throw new JiraClientException();
         }
     }
 
-    private Issue updateIssue(String bugId, ScanResults.XIssue issue, ScanRequest request) throws JiraClientException{
+    private Issue updateIssue(String bugId, ScanResults.XIssue issue, ScanRequest request) throws JiraClientException {
         BugTracker bugTracker = request.getBugTracker();
         String severity = issue.getSeverity();
         Issue jiraIssue = this.getIssue(bugId);
-        if(bugTracker.getClosedStatus().contains(jiraIssue.getStatus().getName())){
+        if (bugTracker.getClosedStatus().contains(jiraIssue.getStatus().getName())) {
             this.transitionIssue(bugId, bugTracker.getOpenTransition());
         }
         IssueInputBuilder issueBuilder = new IssueInputBuilder();
-        String fileUrl = ScanUtils.getFileUrl(request,issue.getFilename());
+        String fileUrl = ScanUtils.getFileUrl(request, issue.getFilename());
         issueBuilder.setDescription(this.getBody(issue, request, fileUrl));
 
-        if(bugTracker.getPriorities().containsKey(severity)) {
+        if (bugTracker.getPriorities().containsKey(severity)) {
             issueBuilder.setFieldValue("priority", ComplexIssueInputFieldValue.with("name",
                     bugTracker.getPriorities().get(severity)));
         }
@@ -254,9 +270,9 @@ public class JiraService {
 
         log.debug("Updating JIRA issue");
         log.debug(issueBuilder.toString());
-        try{
+        try {
             this.issueClient.updateIssue(bugId, issueBuilder.build()).claim();
-        }catch (RestClientException e){
+        } catch (RestClientException e) {
             log.error(ExceptionUtils.getStackTrace(e));
             throw new JiraClientException();
         }
@@ -265,36 +281,36 @@ public class JiraService {
     }
 
     /**
-     * Map custom JIRA fields to specific values (Custom Cx fields, Issue result fields, static fields
+     * Map custom JIRA fields to specific values (Custom Cx fields, Issue result
+     * fields, static fields
      *
      * @param request
      * @param issue
      * @param issueBuilder
      */
-
-    private void mapCustomFields(ScanRequest request, ScanResults.XIssue issue, IssueInputBuilder issueBuilder, boolean update){
+    private void mapCustomFields(ScanRequest request, ScanResults.XIssue issue, IssueInputBuilder issueBuilder, boolean update) {
         BugTracker bugTracker = request.getBugTracker();
 
         log.debug("Handling custom field mappings");
-        if(bugTracker.getFields() == null){
+        if (bugTracker.getFields() == null) {
             return;
         }
 
         String projectKey = bugTracker.getProjectKey();
         String issueTypeStr = bugTracker.getIssueType();
 
-        for(com.checkmarx.flow.dto.Field f: bugTracker.getFields()){
+        for (com.checkmarx.flow.dto.Field f : bugTracker.getFields()) {
 
             String customField = getCustomFieldByName(projectKey, issueTypeStr, f.getJiraFieldName());
             String value;
-            if(update && f.isSkipUpdate()) {
+            if (update && f.isSkipUpdate()) {
                 log.debug("Skip update to field {}", f.getName());
                 continue;
             }
-            if(!ScanUtils.empty(customField)) {
+            if (!ScanUtils.empty(customField)) {
                 /*cx | static | other - specific values that can be linked from scan request or the issue details*/
                 String fieldType = f.getType();
-                if(ScanUtils.empty(fieldType)) {
+                if (ScanUtils.empty(fieldType)) {
                     log.warn("Field type not supplied for custom field: {}. Using 'result' by default.", customField);
                     // use default = result
                     fieldType = "result";
@@ -322,7 +338,7 @@ public class JiraService {
                         break;
                     default:  //result
                         String fieldName = f.getName();
-                        if(fieldName == null) {
+                        if (fieldName == null) {
                             log.warn("Field name not supplied for custom field: {}. Skipping.", customField);
                             /* there is no default, move on to the next field */
                             continue;
@@ -438,7 +454,7 @@ public class JiraService {
                 /*Determine the expected custom field type within JIRA*/
                 if (!ScanUtils.empty(value)) {
                     String jiraFieldType = f.getJiraFieldType();
-                    if(ScanUtils.empty(jiraFieldType)) {
+                    if (ScanUtils.empty(jiraFieldType)) {
                         log.warn("JIRA field type not supplied for custom field: {}. Using 'text' by default.", f.getName());
                         // use default = text
                         jiraFieldType = "text";
@@ -462,7 +478,8 @@ public class JiraService {
                             log.debug("component field");
                             issueBuilder.setComponentsNames(Collections.singletonList(value));
                             break;
-                        case "label": /*csv to array | replace space with _ */
+                        case "label":
+                            /*csv to array | replace space with _ */
                             log.debug("label field");
                             String[] l = StringUtils.split(value, ",");
                             list = new ArrayList<>();
@@ -500,18 +517,18 @@ public class JiraService {
         }
     }
 
-    private SecurityLevel getSecurityLevel(String projectKey, String issueType, String name){
+    private SecurityLevel getSecurityLevel(String projectKey, String issueType, String name) {
         GetCreateIssueMetadataOptions options;
         options = new GetCreateIssueMetadataOptionsBuilder().withExpandedIssueTypesFields().withIssueTypeNames(issueType).withProjectKeys(projectKey).build();
         Iterable<CimProject> metadata = this.issueClient.getCreateIssueMetadata(options).claim();
 
         CimProject cim = metadata.iterator().next();
 
-        Map<String,CimFieldInfo> fields = cim.getIssueTypes().iterator().next().getFields();
+        Map<String, CimFieldInfo> fields = cim.getIssueTypes().iterator().next().getFields();
         CimFieldInfo security = fields.get("security");
         if (security != null) {
             Iterable<Object> allowedValues = security.getAllowedValues();
-            if(allowedValues != null) {
+            if (allowedValues != null) {
                 for (Object lvl : allowedValues) {
                     SecurityLevel secLevel = (SecurityLevel) lvl;
                     if (secLevel.getName().equals(name)) {
@@ -544,9 +561,9 @@ public class JiraService {
                 this.issueClient.transition(issue.getTransitionsUri(), new TransitionInput(transition.getId())).claim();
             } else {
                 log.warn("Issue cannot be transitioned to {}.  Transition is not applicable to issue {}.  Available transitions: {}",
-                transitionName, bugId, transitions.toString());
+                        transitionName, bugId, transitions.toString());
             }
-        } catch(RestClientException e) {
+        } catch (RestClientException e) {
             log.error(ExceptionUtils.getStackTrace(e));
             log.error("There was a problem transitioning issue {}. ", bugId, e);
             throw new JiraClientException();
@@ -554,7 +571,7 @@ public class JiraService {
         return issue;
     }
 
-    private Issue transitionCloseIssue(String bugId, String transitionName, BugTracker bt) throws JiraClientException{
+    private Issue transitionCloseIssue(String bugId, String transitionName, BugTracker bt) throws JiraClientException {
         Issue issue;
         try {
             issue = this.issueClient.getIssue(bugId).claim();
@@ -564,19 +581,19 @@ public class JiraService {
             final Transition transition = getTransitionByName(transitions, transitionName);
             if (transition != null) {
                 //No input for transition
-                if(ScanUtils.empty(bt.getCloseTransitionField()) &&
-                        ScanUtils.empty(bt.getCloseTransitionValue())){
+                if (ScanUtils.empty(bt.getCloseTransitionField())
+                        && ScanUtils.empty(bt.getCloseTransitionValue())) {
                     this.issueClient.transition(issue.getTransitionsUri(), new TransitionInput(transition.getId())).claim();
                 }//Input required for transition
-                else{
+                else {
                     this.issueClient.transition(issue.getTransitionsUri(), new TransitionInput(transition.getId(),
                             Collections.singletonList(new FieldInput(bt.getCloseTransitionField(), ComplexIssueInputFieldValue.with("name", bt.getCloseTransitionValue()))))).claim();
                 }
             } else {
                 log.warn("Issue cannot't be transitioned to {}.  Transition is not applicable to issue {}.  Available transitions: {}",
-                transitionName, bugId, transitions.toString());
+                        transitionName, bugId, transitions.toString());
             }
-        } catch(RestClientException e) {
+        } catch (RestClientException e) {
             log.error(ExceptionUtils.getStackTrace(e));
             log.error("There was a problem transitioning issue {}. ", bugId, e);
             throw new JiraClientException("");
@@ -590,27 +607,26 @@ public class JiraService {
      * @return
      */
     private User getAssignee(String assignee) {
-         return client.getUserClient().getUser(assignee).claim();
+        return client.getUserClient().getUser(assignee).claim();
     }
-
 
     /**
      *
      * @param bugId
      * @param comment
      */
-    private void addCommentToBug(String bugId, String comment){
-        try{
+    private void addCommentToBug(String bugId, String comment) {
+        try {
             Issue issue = this.issueClient.getIssue(bugId).claim();
             this.issueClient.addComment(issue.getCommentsUri(), Comment.valueOf(comment)).claim();
-        }catch(RestClientException e){
+        } catch (RestClientException e) {
             log.error(ExceptionUtils.getStackTrace(e));
         }
     }
 
-
     /**
-     * Returns Jira Transition object based on transition name from a list of transitions
+     * Returns Jira Transition object based on transition name from a list of
+     * transitions
      *
      * @param transitions
      * @param transitionName
@@ -636,56 +652,54 @@ public class JiraService {
         log.debug("Getting custom field {}", fieldName);
         GetCreateIssueMetadataOptions options;
         options = new GetCreateIssueMetadataOptionsBuilder()
-            .withExpandedIssueTypesFields()
-            .withIssueTypeNames(issueType)
-            .withProjectKeys(project)
-            .build();
+                .withExpandedIssueTypesFields()
+                .withIssueTypeNames(issueType)
+                .withProjectKeys(project)
+                .build();
         Iterable<CimProject> metadata = this.issueClient.getCreateIssueMetadata(options).claim();
         CimProject cim = metadata.iterator().next();
         for (CimFieldInfo info : cim.getIssueTypes().iterator().next().getFields().values()) {
-            if(info.getName() != null && info.getName().equals(fieldName)){
+            if (info.getName() != null && info.getName().equals(fieldName)) {
                 return info.getId();
             }
         }
         return null;
     }
 
-    public void getCustomFields(){
+    public void getCustomFields() {
         for (Field p1 : this.metaClient.getFields().claim()) {
             log.info(p1.toString());
         }
     }
 
-    private Map<String, Issue> getJiraIssueMap(List<Issue> issues){
+    private Map<String, Issue> getJiraIssueMap(List<Issue> issues) {
         Map<String, Issue> jiraMap = new HashMap<>();
-        for(Issue issue : issues){
-                jiraMap.put(issue.getSummary(),issue);
+        for (Issue issue : issues) {
+            jiraMap.put(issue.getSummary(), issue);
         }
         return jiraMap;
     }
 
-
-    private Map<String, ScanResults.XIssue> getIssueMap(List<ScanResults.XIssue> issues, ScanRequest request){
+    private Map<String, ScanResults.XIssue> getIssueMap(List<ScanResults.XIssue> issues, ScanRequest request) {
         String issuePrefix = jiraProperties.getIssuePrefix();
         String issuePostfix = jiraProperties.getIssuePostfix();
-        if(issuePrefix == null){
+        if (issuePrefix == null) {
             issuePrefix = "";
         }
-        if(issuePostfix == null){
+        if (issuePostfix == null) {
             issuePostfix = "";
         }
         Map<String, ScanResults.XIssue> map = new HashMap<>();
 
-        if(!flowProperties.isTrackApplicationOnly() &&
-                !ScanUtils.empty(request.getNamespace()) &&
-                !ScanUtils.empty(request.getRepoName()) &&
-                !ScanUtils.empty(request.getBranch())) {
+        if (!flowProperties.isTrackApplicationOnly()
+                && !ScanUtils.empty(request.getNamespace())
+                && !ScanUtils.empty(request.getRepoName())
+                && !ScanUtils.empty(request.getBranch())) {
             for (ScanResults.XIssue issue : issues) {
                 String key = String.format(ScanUtils.JIRA_ISSUE_KEY, issuePrefix, issue.getVulnerability(), issue.getFilename(), request.getBranch(), issuePostfix);
                 map.put(key, issue);
             }
-        }
-        else{
+        } else {
             for (ScanResults.XIssue issue : issues) {
                 String key = String.format(ScanUtils.JIRA_ISSUE_KEY_2, issuePrefix, issue.getVulnerability(), issue.getFilename(), issuePostfix);
                 map.put(key, issue);
@@ -694,77 +708,74 @@ public class JiraService {
         return map;
     }
 
-    private String getBody(ScanResults.XIssue issue, ScanRequest request, String fileUrl){
+    private String getBody(ScanResults.XIssue issue, ScanRequest request, String fileUrl) {
         StringBuilder body = new StringBuilder();
-        if(!ScanUtils.empty(jiraProperties.getDescriptionPrefix())){
+        if (!ScanUtils.empty(jiraProperties.getDescriptionPrefix())) {
             body.append(jiraProperties.getDescriptionPrefix());
         }
-        if(!flowProperties.isTrackApplicationOnly() &&
-                !ScanUtils.empty(request.getNamespace()) &&
-                !ScanUtils.empty(request.getRepoName()) &&
-                !ScanUtils.empty(request.getBranch())) {
+        if (!flowProperties.isTrackApplicationOnly()
+                && !ScanUtils.empty(request.getNamespace())
+                && !ScanUtils.empty(request.getRepoName())
+                && !ScanUtils.empty(request.getBranch())) {
             body.append(String.format(ScanUtils.JIRA_ISSUE_BODY, issue.getVulnerability(), issue.getFilename(), request.getBranch())).append(ScanUtils.CRLF).append(ScanUtils.CRLF);
-        }
-        else{
+        } else {
             body.append(String.format(ScanUtils.JIRA_ISSUE_BODY_2, issue.getVulnerability(), issue.getFilename())).append(ScanUtils.CRLF).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(issue.getDescription())) {
+        if (!ScanUtils.empty(issue.getDescription())) {
             body.append(issue.getDescription().trim()).append(ScanUtils.CRLF).append(ScanUtils.CRLF);
         }
 
-        if(!ScanUtils.empty(request.getNamespace())) {
+        if (!ScanUtils.empty(request.getNamespace())) {
             body.append("*Namespace:* ").append(request.getNamespace()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(request.getRepoName())) {
+        if (!ScanUtils.empty(request.getRepoName())) {
             body.append("*Repository:* ").append(request.getRepoName()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(request.getBranch())) {
+        if (!ScanUtils.empty(request.getBranch())) {
             body.append("*Branch:* ").append(request.getBranch()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(request.getRepoUrl())) {
+        if (!ScanUtils.empty(request.getRepoUrl())) {
             body.append("*Repository Url:* ").append(request.getRepoUrl()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(request.getApplication())) {
+        if (!ScanUtils.empty(request.getApplication())) {
             body.append("*Application:* ").append(request.getApplication()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(request.getProject())) {
+        if (!ScanUtils.empty(request.getProject())) {
             body.append("*Cx-Project:* ").append(request.getProject()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(request.getTeam())) {
+        if (!ScanUtils.empty(request.getTeam())) {
             body.append("*Cx-Team:* ").append(request.getTeam()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(issue.getSeverity())) {
+        if (!ScanUtils.empty(issue.getSeverity())) {
             body.append("*Severity:* ").append(issue.getSeverity()).append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(issue.getCwe())) {
+        if (!ScanUtils.empty(issue.getCwe())) {
             body.append("*CWE:* ").append(issue.getCwe()).append(ScanUtils.CRLF);
         }
 
         body.append(ScanUtils.CRLF).append("*Addition Info*").append(ScanUtils.CRLF).append("----").append(ScanUtils.CRLF);
-        if(issue.getLink() != null && !issue.getLink().isEmpty()){
+        if (issue.getLink() != null && !issue.getLink().isEmpty()) {
             body.append("[Checkmarx|").append(issue.getLink()).append("]").append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(issue.getCwe()) && !ScanUtils.empty(flowProperties.getMitreUrl())) {
+        if (!ScanUtils.empty(issue.getCwe()) && !ScanUtils.empty(flowProperties.getMitreUrl())) {
             body.append("[Mitre Details|").append(String.format(flowProperties.getMitreUrl(), issue.getCwe())).append("]").append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(flowProperties.getCodebashUrl())) {
+        if (!ScanUtils.empty(flowProperties.getCodebashUrl())) {
             body.append("[Training|").append(flowProperties.getCodebashUrl()).append("]").append(ScanUtils.CRLF);
         }
-        if(!ScanUtils.empty(flowProperties.getWikiUrl())) {
+        if (!ScanUtils.empty(flowProperties.getWikiUrl())) {
             body.append("[Guidance|").append(flowProperties.getWikiUrl()).append("]").append(ScanUtils.CRLF);
         }
-        if(issue.getDetails() != null && !issue.getDetails().isEmpty()) {
+        if (issue.getDetails() != null && !issue.getDetails().isEmpty()) {
             body.append("Lines: ");
             for (Map.Entry<Integer, String> entry : issue.getDetails().entrySet()) {
                 if (!ScanUtils.empty(fileUrl)) {
                     if (entry.getKey() != null) {
-                        if(request.getRepoType().equals(ScanRequest.Repository.BITBUCKETSERVER)){
+                        if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKETSERVER)) {
                             body.append("[").append(entry.getKey()).append("|").append(fileUrl).append("#").append(entry.getKey()).append("] ");
-                        }
-                        else if(request.getRepoType().equals(ScanRequest.Repository.BITBUCKET)){ //BB Cloud
+                        } else if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKET)) { //BB Cloud
                             body.append("[").append(entry.getKey()).append("|").append(fileUrl).append("#lines-").append(entry.getKey()).append("] ");
-                        }
-                        else {
+                        } else {
                             body.append("[").append(entry.getKey()).append("|").append(fileUrl).append("#L").append(entry.getKey()).append("] ");
                         }
                     }
@@ -776,21 +787,18 @@ public class JiraService {
             }
 
             body.append(ScanUtils.CRLF).append(ScanUtils.CRLF);
-            for (Map.Entry<Integer, String> entry : issue.getDetails().entrySet()){
-                if(entry.getKey() != null && entry.getValue() != null){
+            for (Map.Entry<Integer, String> entry : issue.getDetails().entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
                     body.append("----").append(ScanUtils.CRLF);
-                    if(!ScanUtils.empty(fileUrl)) {
-                        if(request.getRepoType().equals(ScanRequest.Repository.BITBUCKETSERVER)){
+                    if (!ScanUtils.empty(fileUrl)) {
+                        if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKETSERVER)) {
                             body.append("[Line #").append(entry.getKey()).append(":|").append(fileUrl).append("#").append(entry.getKey()).append("]").append(ScanUtils.CRLF);
-                        }
-                        else if(request.getRepoType().equals(ScanRequest.Repository.BITBUCKET)){ //BB Cloud
+                        } else if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKET)) { //BB Cloud
                             body.append("[Line #").append(entry.getKey()).append(":|").append(fileUrl).append("#lines-").append(entry.getKey()).append("]").append(ScanUtils.CRLF);
-                        }
-                        else {
+                        } else {
                             body.append("[Line #").append(entry.getKey()).append(":|").append(fileUrl).append("#L").append(entry.getKey()).append("]").append(ScanUtils.CRLF);
                         }
-                    }
-                    else {
+                    } else {
                         body.append("Line #").append(entry.getKey()).append(ScanUtils.CRLF);
                     }
                     body.append("{code}").append(ScanUtils.CRLF);
@@ -801,50 +809,61 @@ public class JiraService {
             body.append("----").append(ScanUtils.CRLF);
         }
 
-        if(issue.getOsaDetails()!=null){
-            for(ScanResults.OsaDetails o: issue.getOsaDetails()){
+        if (issue.getOsaDetails() != null) {
+            for (ScanResults.OsaDetails o : issue.getOsaDetails()) {
                 body.append(ScanUtils.CRLF);
-                if(!ScanUtils.empty(o.getCve())) {
+                if (!ScanUtils.empty(o.getCve())) {
                     body.append("h3.").append(o.getCve()).append(ScanUtils.CRLF);
                 }
                 body.append("{noformat}");
-                if(!ScanUtils.empty(o.getSeverity())) {
+                if (!ScanUtils.empty(o.getSeverity())) {
                     body.append("Severity: ").append(o.getSeverity()).append(ScanUtils.CRLF);
                 }
-                if(!ScanUtils.empty(o.getVersion())) {
+                if (!ScanUtils.empty(o.getVersion())) {
                     body.append("Version: ").append(o.getVersion()).append(ScanUtils.CRLF);
                 }
-                if(!ScanUtils.empty(o.getDescription())) {
+                if (!ScanUtils.empty(o.getDescription())) {
                     body.append("Description: ").append(o.getDescription()).append(ScanUtils.CRLF);
                 }
-                if(!ScanUtils.empty(o.getRecommendation())){
+                if (!ScanUtils.empty(o.getRecommendation())) {
                     body.append("Recommendation: ").append(o.getRecommendation()).append(ScanUtils.CRLF);
                 }
-                if(!ScanUtils.empty(o.getUrl())) {
+                if (!ScanUtils.empty(o.getUrl())) {
                     body.append("URL: ").append(o.getUrl());
                 }
                 body.append("{noformat}");
                 body.append(ScanUtils.CRLF);
             }
         }
-        if(!ScanUtils.empty(jiraProperties.getDescriptionPostfix())){
+        if (!ScanUtils.empty(jiraProperties.getDescriptionPostfix())) {
             body.append(jiraProperties.getDescriptionPostfix());
         }
         return body.toString();
     }
 
-
-    Map<String, List<String>> process(ScanResults results, ScanRequest request) throws JiraClientException{
+    Map<String, List<String>> process(ScanResults results, ScanRequest request) throws JiraClientException {
         Map<String, ScanResults.XIssue> map;
         Map<String, Issue> jiraMap;
+        List<Issue> IssuesParent;
         List<String> newIssues = new ArrayList<>();
         List<String> updatedIssues = new ArrayList<>();
         List<String> closedIssues = new ArrayList<>();
+        if (this.jiraProperties.isChild()) {
+            Parent = new ScanRequest(request);
+            BugTracker bugTracker;
+            bugTracker = Parent.getBugTracker();
+            bugTracker.setProjectKey(ParentUrl);
+            Parent.setBugTracker(bugTracker);
+            IssuesParent = this.getIssues(Parent);
+        } else {
+            IssuesParent = this.getIssues(request);
+
+        }
 
         log.info("Processing Results and publishing findings to Jira");
         String application = request.getApplication();
-        if(!ScanUtils.empty(application)){
-            application = application.replaceAll("[^a-zA-Z0-9-_.+]+","_");
+        if (!ScanUtils.empty(application)) {
+            application = application.replaceAll("[^a-zA-Z0-9-_.+]+", "_");
             request.setApplication(application);
         }
 
@@ -852,7 +871,7 @@ public class JiraService {
         map = this.getIssueMap(results.getXIssues(), request);
         jiraMap = this.getJiraIssueMap(issues);
 
-        for (Map.Entry<String, ScanResults.XIssue> xIssue : map.entrySet()){
+        for (Map.Entry<String, ScanResults.XIssue> xIssue : map.entrySet()) {
             try {
                 ScanResults.XIssue currentIssue = xIssue.getValue();
 
@@ -867,30 +886,36 @@ public class JiraService {
                         if (updatedIssue != null) {
                             log.debug("Update completed for issue #{}", updatedIssue.getKey());
                             updatedIssues.add(updatedIssue.getKey());
-                            if(jiraProperties.isUpdateComment() && !ScanUtils.empty(jiraProperties.getUpdateCommentValue())) {
+                            if (jiraProperties.isUpdateComment() && !ScanUtils.empty(jiraProperties.getUpdateCommentValue())) {
                                 addCommentToBug(i.getKey(), jiraProperties.getUpdateCommentValue());
                             }
                         }
                     } else {
                         log.info("Skipping issue marked as false-positive or has False Positive state with key {}", xIssue.getKey());
                     }
-                }
-                else {
+                } else {
                     /*Create the new issue*/
-                    log.debug("Creating new issue with key {}", xIssue.getKey());
-                    String newIssue =  this.createIssue(currentIssue, request);
-                    newIssues.add(newIssue);
-                    log.info("New issue created. #{}", newIssue);
+                    if (!jiraProperties.isChild() || !ParentCheck(xIssue.getKey(), IssuesParent)) {
+
+                        if (jiraProperties.isChild()) {
+                            log.info("Issue not found in parent creating issue for child");
+                        }
+
+                        log.debug("Creating new issue with key {}", xIssue.getKey());
+                        String newIssue = this.createIssue(currentIssue, request);
+                        newIssues.add(newIssue);
+                        log.info("New issue created. #{}", newIssue);
+                    }
                 }
-            }catch(RestClientException e){
-                log.error("Error occurred while processing issue with key {}",xIssue.getKey(), e);
+            } catch (RestClientException e) {
+                log.error("Error occurred while processing issue with key {}", xIssue.getKey(), e);
                 log.error(ExceptionUtils.getStackTrace(e));
                 throw new JiraClientException();
             }
         }
 
         /*Check if an issue exists in Jira but not within results and close if not*/
-        for (Map.Entry<String, Issue> jiraIssue : jiraMap.entrySet()){
+        for (Map.Entry<String, Issue> jiraIssue : jiraMap.entrySet()) {
             try {
                 if (!map.containsKey(jiraIssue.getKey())) {
                     if (request.getBugTracker().getOpenStatus().contains(jiraIssue.getValue().getStatus().getName())) {
@@ -901,7 +926,7 @@ public class JiraService {
                         closedIssues.add(jiraIssue.getValue().getKey());
                     }
                 }
-            }catch(HttpClientErrorException e){
+            } catch (HttpClientErrorException e) {
                 log.error("Error occurred while processing issue with key {} {}", jiraIssue.getKey(), e);
                 log.error(ExceptionUtils.getStackTrace(e));
             }
@@ -912,5 +937,19 @@ public class JiraService {
                 "updated", updatedIssues,
                 "closed", closedIssues
         );
+    }
+
+    boolean ParentCheck(String Key, List<Issue> Issues) {
+        Map<String, Issue> jiraMap;
+        jiraMap = this.getJiraIssueMap(Issues);
+        if (this.jiraProperties.isChild()) {
+
+            if (jiraMap.containsKey(Key)) {
+                log.info("Issue found in parent not creating issue for child");
+                return true;
+            }
+        }
+        return false;
+
     }
 }


### PR DESCRIPTION
added new parameters
jira.child (Boolean)
jira.ParentUrl(String)
cx-flow.ApplicationRepoOnly (Boolean)
checkmarx.nonamespace: (Boolean)

Jira Key = ApplicationRepoOnly
Project team's in Jira sometimes have to have more than one repo to support a single application. We need to ensure that cxFlow supports a Jira key that includes: Application and Repo name.

multilayer Jira support
Avoid duplicate issues from being created across the program Better metrics for teams vs ARTs
Ability to use Jira at multiple levels to manage "Application Security Bugs"

Naming Convention issue
A bug that caused the webhook to create new projects in checkmarks as it could not read the cmd line runners projects.